### PR TITLE
fix: dbus object of login collection is not exported at first login

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-keyring (46.2-1deepin1) unstable; urgency=medium
+
+  * fix: dbus object of login collection is not exported at first login
+
+ -- zsien <quezhiyong@deepin.org>  Fri, 13 Dec 2024 10:24:03 +0800
+
 gnome-keyring (46.2-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/patches/deepin-Ensure-the-login-collection-is-registered-after-unlocking.patch
+++ b/debian/patches/deepin-Ensure-the-login-collection-is-registered-after-unlocking.patch
@@ -1,0 +1,156 @@
+From: zsien <i@zsien.cn>
+Date: Fri, 13 Dec 2024 10:19:55 +0800
+Subject: Ensure the login collection is registered after unlocking
+
+---
+ daemon/control/gkd-control-server.c |  8 ++++++--
+ daemon/dbus/gkd-dbus-secrets.c      |  6 ++++++
+ daemon/dbus/gkd-dbus.h              |  2 ++
+ daemon/dbus/gkd-secret-objects.c    |  7 +++++++
+ daemon/dbus/gkd-secret-objects.h    |  3 +++
+ daemon/dbus/gkd-secret-service.c    | 13 +++++++++++++
+ daemon/dbus/gkd-secret-service.h    |  2 ++
+ daemon/gkd-main.c                   |  6 ++++++
+ daemon/gkd-main.h                   |  2 ++
+ 9 files changed, 47 insertions(+), 2 deletions(-)
+
+diff --git a/daemon/control/gkd-control-server.c b/daemon/control/gkd-control-server.c
+index 5ef307d..dcf6471 100644
+--- a/daemon/control/gkd-control-server.c
++++ b/daemon/control/gkd-control-server.c
+@@ -25,6 +25,7 @@
+ 
+ #include "daemon/gkd-main.h"
+ #include "daemon/gkd-util.h"
++#include "daemon/dbus/gkd-dbus.h"
+ 
+ #include "egg/egg-buffer.h"
+ #include "egg/egg-cleanup.h"
+@@ -85,10 +86,13 @@ control_unlock_login (EggBuffer *buffer)
+ 	if (!egg_buffer_get_string (buffer, offset, &offset, &master, egg_secure_realloc))
+ 		return GKD_CONTROL_RESULT_FAILED;
+ 
+-	if (gkd_login_unlock (master))
++	if (gkd_login_unlock (master)) {
+ 		res = GKD_CONTROL_RESULT_OK;
+-	else
++		if (gkd_main_secrets_started ())
++			gkd_dbus_ensure_login_collection_is_registered ();
++	} else {
+ 		res = GKD_CONTROL_RESULT_DENIED;
++	}
+ 
+ 	egg_secure_strfree (master);
+ 	return res;
+diff --git a/daemon/dbus/gkd-dbus-secrets.c b/daemon/dbus/gkd-dbus-secrets.c
+index 207524b..7227dd8 100644
+--- a/daemon/dbus/gkd-dbus-secrets.c
++++ b/daemon/dbus/gkd-dbus-secrets.c
+@@ -156,3 +156,9 @@ gkd_dbus_secrets_cleanup (GDBusConnection *conn)
+ 		secrets_service = NULL;
+ 	}
+ }
++
++void
++gkd_dbus_ensure_login_collection_is_registered (void)
++{
++	gkd_secret_service_ensure_login_collection_is_registered (secrets_service);
++}
+diff --git a/daemon/dbus/gkd-dbus.h b/daemon/dbus/gkd-dbus.h
+index 8a9ca45..9cd2a55 100644
+--- a/daemon/dbus/gkd-dbus.h
++++ b/daemon/dbus/gkd-dbus.h
+@@ -38,4 +38,6 @@ gchar*        gkd_dbus_singleton_control        (void);
+ gboolean      gkd_dbus_invocation_matches_caller (GDBusMethodInvocation *invocation,
+ 						  const char            *caller);
+ 
++void          gkd_dbus_ensure_login_collection_is_registered (void);
++
+ #endif /* GKD_DBUS_H */
+diff --git a/daemon/dbus/gkd-secret-objects.c b/daemon/dbus/gkd-secret-objects.c
+index 90493df..6c8adb4 100644
+--- a/daemon/dbus/gkd-secret-objects.c
++++ b/daemon/dbus/gkd-secret-objects.c
+@@ -1660,3 +1660,10 @@ gkd_secret_objects_unregister_collection (GkdSecretObjects *self,
+ 		return;
+ 	}
+ }
++
++gboolean
++gkd_secret_objects_check_collection_is_registered  (GkdSecretObjects *self,
++                                                    const gchar *collection_path)
++{
++	return g_hash_table_lookup (self->collections_to_skeletons, collection_path) != NULL;
++}
+diff --git a/daemon/dbus/gkd-secret-objects.h b/daemon/dbus/gkd-secret-objects.h
+index e9b61d4..9051674 100644
+--- a/daemon/dbus/gkd-secret-objects.h
++++ b/daemon/dbus/gkd-secret-objects.h
+@@ -102,4 +102,7 @@ void                gkd_secret_objects_register_collection       (GkdSecretObjec
+ void                gkd_secret_objects_unregister_collection     (GkdSecretObjects *self,
+                                                                   const gchar *collection_path);
+ 
++gboolean            gkd_secret_objects_check_collection_is_registered  (GkdSecretObjects *self,
++                                                                        const gchar *collection_path);
++
+ #endif /* __GKD_SECRET_OBJECTS_H__ */
+diff --git a/daemon/dbus/gkd-secret-service.c b/daemon/dbus/gkd-secret-service.c
+index a0cd9e8..066ee02 100644
+--- a/daemon/dbus/gkd-secret-service.c
++++ b/daemon/dbus/gkd-secret-service.c
+@@ -1446,3 +1446,16 @@ gkd_secret_service_emit_collection_changed (GkdSecretService *self,
+ 
+ 	gkd_exported_service_emit_collection_changed (self->skeleton, collection_path);
+ }
++
++void
++gkd_secret_service_ensure_login_collection_is_registered (GkdSecretService *self)
++{
++	g_return_if_fail (GKD_SECRET_IS_SERVICE (self));
++
++	gchar *collection_path = gkd_secret_util_build_path (SECRET_COLLECTION_PREFIX, "login", strlen("login"));
++	if (gkd_secret_objects_check_collection_is_registered (self->objects, collection_path)) {
++		return;
++	}
++
++	gkd_secret_objects_register_collection (self->objects, collection_path);
++}
+diff --git a/daemon/dbus/gkd-secret-service.h b/daemon/dbus/gkd-secret-service.h
+index f95ac96..960da54 100644
+--- a/daemon/dbus/gkd-secret-service.h
++++ b/daemon/dbus/gkd-secret-service.h
+@@ -84,4 +84,6 @@ void                    gkd_secret_service_emit_collection_changed (GkdSecretSer
+ 
+ gchar **                gkd_secret_service_get_collections         (GkdSecretService *self);
+ 
++void                    gkd_secret_service_ensure_login_collection_is_registered (GkdSecretService *self);
++
+ #endif /* ___SECRET_SERVICE_H__ */
+diff --git a/daemon/gkd-main.c b/daemon/gkd-main.c
+index 664a084..0e69b4d 100644
+--- a/daemon/gkd-main.c
++++ b/daemon/gkd-main.c
+@@ -822,6 +822,12 @@ gkd_main_complete_initialization (const gchar *components)
+ 	gkr_daemon_initialize_steps (components);
+ }
+ 
++gboolean
++gkd_main_secrets_started (void)
++{
++	return secrets_started;
++}
++
+ static gboolean
+ on_login_timeout (gpointer data)
+ {
+diff --git a/daemon/gkd-main.h b/daemon/gkd-main.h
+index b847be6..5e9ba15 100644
+--- a/daemon/gkd-main.h
++++ b/daemon/gkd-main.h
+@@ -27,4 +27,6 @@ void           gkd_main_quit                    (void);
+ 
+ void           gkd_main_complete_initialization (const gchar *components);
+ 
++gboolean        gkd_main_secrets_started        (void);
++
+ #endif /* GKD_MAIN_H_ */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@ egg-secure-memory-Add-a-warning-if-gnome-keyring-36-happe.patch
 03_kfreebsd.patch
 05_skip-known-test-failures.patch
 systemd-Start-with-graphical-session-instead-of-default.patch
+deepin-Ensure-the-login-collection-is-registered-after-unlocking.patch


### PR DESCRIPTION
解锁 login 后，确保它被导出到 dbus，
https://gitlab.gnome.org/GNOME/gnome-keyring/-/merge_requests/78

Log: 修复首次登入无法开启开发者模式
PMS: bug-281701