### PR TITLE
fix: 密码过期时登录界面修改密码导致的问题

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-keyring (46.2-1deepin4) unstable; urgency=medium
+
+  * if the password is not successfully modified, do not stash the new password
+
+ -- fuleyi <fuleyi@uniontech.com>  Thu, 10 Jul 2025 14:25:00 +0800
+
 gnome-keyring (46.2-1deepin3) unstable; urgency=medium
 
   * add a feature to specify the working directory

--- a/debian/patches/0005-fix-chauthtok-stash-password.patch
+++ b/debian/patches/0005-fix-chauthtok-stash-password.patch
@@ -1,0 +1,34 @@
+Index: gnome-keyring/daemon/gkd-main.c
+===================================================================
+--- gnome-keyring.orig/daemon/gkd-main.c
++++ gnome-keyring/daemon/gkd-main.c
+@@ -574,8 +574,14 @@ discover_other_daemon (DiscoverFunc call
+ 	/* An environment variable from an already running daemon */
+ 	control_env = g_getenv (GKD_UTIL_ENV_CONTROL);
+ 	if (control_env && control_env[0]) {
+-		if ((callback)(control_env))
+-			return TRUE;
++		struct stat st;
++		if (lstat(control_env, &st) < 0) {
++			g_warning("discover other daemon: couldn't access gnome keyring socket: %s: %s", control_env, strerror(errno));
++			control_env = NULL;
++		} else {
++			if ((callback)(control_env))
++				return TRUE;
++		}
+ 	}
+ 
+ 	/* Or the default location when no evironment variable */
+Index: gnome-keyring/pam/gkr-pam-module.c
+===================================================================
+--- gnome-keyring.orig/pam/gkr-pam-module.c
++++ gnome-keyring/pam/gkr-pam-module.c
+@@ -1052,7 +1052,7 @@ pam_chauthtok_update (pam_handle_t *ph,
+ 	 * Likely the daemon is being started later in the session if we weren't
+ 	 * allowed to autostart it here. Store the password for our session handler
+ 	 */
+-	if (!(args & ARG_AUTO_START))
++	if (!(args & ARG_AUTO_START) && ret == PAM_SUCCESS)
+ 		stash_password_for_session (ph, password);
+ 
+ 	return ret;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ egg-secure-memory-Add-a-warning-if-gnome-keyring-36-happe.patch
 systemd-Start-with-graphical-session-instead-of-default.patch
 deepin-Ensure-the-login-collection-is-registered-after-unlocking.patch
 0003-uniontech-feat-set-default-locate-keyrings-directory.patch
+0005-fix-chauthtok-stash-password.patch


### PR DESCRIPTION
正常登录流程是auth->session，密码过期时登录流程是auth->password->session，auth缓存密码，password阶段修改密码失败但却依旧替换了缓存里的密码为新密码。 修复为改密成功才替换。

Log: 密码过期时登录界面修改密码导致的问题
pms: BUG-317435