### PR TITLE
fix: change daemon control file error log to warning level

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-keyring (46.2-1deepin6) unstable; urgency=medium
+
+  * Change daemon control file error log to warning level
+
+ -- fuleyi <fuleyi@uniontech.com>  Wed, 04 Feb 2026 11:44:57 +0800
+
 gnome-keyring (46.2-1deepin5) unstable; urgency=medium
 
   * update tips to unlock login keyring

--- a/debian/patches/0006-change-control-file-error-to-warning.patch
+++ b/debian/patches/0006-change-control-file-error-to-warning.patch
@@ -1,0 +1,31 @@
+Index: gnome-keyring/pam/gkr-pam-module.c
+===================================================================
+--- gnome-keyring.orig/pam/gkr-pam-module.c
++++ gnome-keyring/pam/gkr-pam-module.c
+@@ -646,7 +646,7 @@ stop_daemon (pam_handle_t *ph,
+ 
+ 	res = get_control_file(ph, control);
+ 	if (res != GKD_CONTROL_RESULT_OK) {
+-		syslog (GKR_LOG_ERR, "gkr-pam: unable to locate daemon control file");
++		syslog (GKR_LOG_WARN, "gkr-pam: unable to locate daemon control file");
+ 		return PAM_SERVICE_ERR;
+ 	}
+ 
+@@ -679,7 +679,7 @@ unlock_keyring (pam_handle_t *ph,
+ 
+ 	res = get_control_file(ph, control);
+ 	if (res != GKD_CONTROL_RESULT_OK) {
+-		syslog (GKR_LOG_ERR, "gkr-pam: unable to locate daemon control file");
++		syslog (GKR_LOG_WARN, "gkr-pam: unable to locate daemon control file");
+ 		if (res == GKD_CONTROL_RESULT_NO_DAEMON && need_daemon)
+ 			*need_daemon = 1;
+ 		return PAM_SERVICE_ERR;
+@@ -723,7 +723,7 @@ change_keyring_password (pam_handle_t *
+ 
+ 	res = get_control_file(ph, control);
+ 	if (res != GKD_CONTROL_RESULT_OK) {
+-		syslog (GKR_LOG_ERR, "gkr-pam: unable to locate daemon control file");
++		syslog (GKR_LOG_WARN, "gkr-pam: unable to locate daemon control file");
+ 		return PAM_SERVICE_ERR;
+ 	}
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@ deepin-Ensure-the-login-collection-is-registered-after-unlocking.patch
 0003-uniontech-feat-set-default-locate-keyrings-directory.patch
 0005-fix-chauthtok-stash-password.patch
 update-tips-to-unlock-login-keyring.patch
+0006-change-control-file-error-to-warning.patch


### PR DESCRIPTION
Changed the log level for daemon control file errors from GKR_LOG_ERR to GKR_LOG_WARN in three PAM module functions: stop_daemon, unlock_keyring, and change_keyring_password. This modification prevents unnecessary system error logging when the daemon control file cannot be located, which may occur during normal system operations or when the daemon is not running. The change reduces noise in system logs while maintaining functionality.

Log: Reduced severity of daemon control file missing warnings

Influence:
1. Test PAM authentication when gnome-keyring daemon is not running
2. Verify system logs no longer show errors for missing control files
3. Test keyring unlock functionality with and without daemon running
4. Check that password change operations work correctly
5. Verify that warning messages still appear in logs when appropriate

fix: 将守护进程控制文件错误日志级别改为警告级别

将 PAM 模块三个函数（stop_daemon、unlock_keyring 和
change_keyring_password）中的守护进程控制文件错误日志级别从 GKR_LOG_ERR 改为 GKR_LOG_WARN。此修改可防止在无法定位守护进程控制文件时产生不必要的
系统错误日志记录，这种情况可能在正常系统操作或守护进程未运行时发生。该变
更减少了系统日志中的噪音，同时保持了功能完整性。

Log: 降低了守护进程控制文件缺失警告的严重级别
PMS: BUG-349919
Influence:
1. 测试 gnome-keyring 守护进程未运行时的 PAM 认证
2. 验证系统日志不再显示控制文件缺失的错误信息
3. 测试守护进程运行和未运行时的密钥环解锁功能
4. 检查密码更改操作是否正常工作
5. 确认警告消息在适当时仍会出现在日志中