### PR TITLE
feat: 修改登录密码后确保登录集合已注册

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-keyring (46.2-1deepin7) unstable; urgency=medium
+
+  * Ensure the login collection is registered after unlocking
+
+ -- fuleyi <fuleyi@uniontech.com>  Fri, 06 Feb 2026 15:31:49 +0800
+
 gnome-keyring (46.2-1deepin6) unstable; urgency=medium
 
   * Change daemon control file error log to warning level

--- a/debian/patches/deepin-Ensure-the-login-collection-is-registered-after-change-login.patch
+++ b/debian/patches/deepin-Ensure-the-login-collection-is-registered-after-change-login.patch
@@ -1,0 +1,17 @@
+Index: gnome-keyring/daemon/control/gkd-control-server.c
+===================================================================
+--- gnome-keyring.orig/daemon/control/gkd-control-server.c
++++ gnome-keyring/daemon/control/gkd-control-server.c
+@@ -115,8 +115,11 @@ control_change_login (EggBuffer *buffer)
+ 		return GKD_CONTROL_RESULT_FAILED;
+ 	}
+ 
+-	if (gkd_login_change_lock (original, master))
++	if (gkd_login_change_lock (original, master)){
+ 		res = GKD_CONTROL_RESULT_OK;
++		if (gkd_main_secrets_started ())
++			gkd_dbus_ensure_login_collection_is_registered ();
++	}	
+ 	else
+ 		res = GKD_CONTROL_RESULT_DENIED;
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@ deepin-Ensure-the-login-collection-is-registered-after-unlocking.patch
 0005-fix-chauthtok-stash-password.patch
 update-tips-to-unlock-login-keyring.patch
 0006-change-control-file-error-to-warning.patch
+deepin-Ensure-the-login-collection-is-registered-after-change-login.patch


### PR DESCRIPTION
- 添加 deepin-Ensure-the-login-collection-is-registered-after-change-login.patch
- 更新 debian/patches/series 包含新补丁
- 在 control_change_login() 成功修改密码后调用 gkd_dbus_ensure_login_collection_is_registered()

Log: 添加补丁以在修改登录密码后注册登录集合。这是对现有解锁补丁的补充，同时处理密码修改场景。
PMS: BUG-350091
Influence: keyring unlock